### PR TITLE
Fix error: The value True 

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -6,7 +6,7 @@
 
 - name: Patching | APT - Upgrade packages
   apt:
-    upgrade: true
+    upgrade: "yes"
   when:
     - not patching__upgrade_all | bool
 


### PR DESCRIPTION
Fix error: The value True (type bool) in a string field was converted to u'True' (type string).
According to:
https://docs.ansible.com/ansible/latest/modules/apt_module.html
the options of upgrade are:
dit, full, no, safe, yes